### PR TITLE
Update HASS Data Detective to 0.9

### DIFF
--- a/jupyterlab/requirements.txt
+++ b/jupyterlab/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.6.3
 bokeh==1.0.2
 geopy==1.18.0
-HASS-data-detective==0.7
+HASS-data-detective==0.9
 influxdb==5.2.1
 ipywidgets==7.4.2
 jupyterlab_github==0.7.0


### PR DESCRIPTION
# Proposed Changes

Update HASS Data Detective to 0.9, which includes a bunch of extra warnings.

## Related Issues

https://github.com/robmarkcole/HASS-data-detective/releases/tag/0.9

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><img src="https://avatars1.githubusercontent.com/u/11855322?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/robmarkcole/HASS-data-detective">robmarkcole/HASS-data-detective</a></strong></div><div>Explore and analyse your Home Assistant data. Contribute to robmarkcole/HASS-data-detective development by creating an account on GitHub.</div></blockquote>