### PR TITLE
Fix uploading larger files than 1 mb

### DIFF
--- a/jupyterlab/rootfs/etc/nginx/nginx.conf
+++ b/jupyterlab/rootfs/etc/nginx/nginx.conf
@@ -18,6 +18,7 @@ http {
     keepalive_timeout  65;
     lua_shared_dict    auths 16k;
     resolver           %%dns_host%%;
+    client_max_body_size 0;
 
     upstream jupyter {
         ip_hash;


### PR DESCRIPTION
erroring out with
[error] 524#524: client intended to send too large body

Actually this also happens if the output data from the cells gets too large.

# Proposed Changes

switch off checking of size by setting client_max_body_size 0 in nginx.conf
works like a charm.

## Related Issues

https://github.com/jupyterlab/jupyterlab/issues/4214
