### PR TITLE
:arrow_up: Upgrades NodeJS to 12.18.2-1nodesource1

### DIFF
--- a/jupyterlab/Dockerfile
+++ b/jupyterlab/Dockerfile
@@ -59,7 +59,7 @@ RUN \
     && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     \
     && apt-get install -y --no-install-recommends \
-        nodejs=12.17.0-1nodesource1 \
+        nodejs=12.18.2-1nodesource1 \
     \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 \
     \


### PR DESCRIPTION
# Proposed Changes

`12.17.0-1nodesource1` was throwing an error, saying it wasn't found while building the container. 
Changed it to `12.18.2-1nodesource1`, which fixed the issue

## Logs of current version:

```bash
## Creating apt sources list file for the NodeSource Node.js 12.x repo...

+ echo 'deb https://deb.nodesource.com/node_12.x buster main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src https://deb.nodesource.com/node_12.x buster main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit:1 http://deb.debian.org/debian buster InRelease
Hit:2 http://security.debian.org/debian-security buster/updates InRelease
Hit:3 http://deb.debian.org/debian buster-updates InRelease
Get:4 https://deb.nodesource.com/node_12.x buster InRelease [4584 B]
Get:5 https://deb.nodesource.com/node_12.x buster/main amd64 Packages [763 B]
Fetched 5347 B in 1s (4102 B/s)
Reading package lists...

## Run `sudo apt-get install -y nodejs` to install Node.js 12.x and npm
## You may also need development tools to build native addons:
     sudo apt-get install gcc g++ make
## To install the Yarn package manager, run:
     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install yarn


Reading package lists...
Building dependency tree...
Reading state information...
E: Version '12.17.0-1nodesource1' for 'nodejs' was not found
The command '/bin/bash -o pipefail -c MAKEFLAGS="-j$(nproc)"     && export MAKEFLAGS         && apt-get update     && apt-get install -y --no-install-recommends         build-essential=12.6         dirmngr=2.2.12-1+deb10u1         git=1:2.20.1-2+deb10u3         gpg-agent=2.2.12-1+deb10u1         gpg=2.2.12-1+deb10u1         libffi-dev=3.2.1-9         libffi6=3.2.1-9         libfreetype6-dev=2.9.1-3+deb10u1         libfreetype6=2.9.1-3+deb10u1         libjpeg62-turbo-dev=1:1.5.2-2+b1         libjpeg62-turbo=1:1.5.2-2+b1         libmariadb-dev=1:10.3.22-0+deb10u1         libmariadb3=1:10.3.22-0+deb10u1         libnginx-mod-http-lua=1.14.2-2+deb10u1         libpng-dev=1.6.36-6         libpng16-16=1.6.36-6         libpq-dev=11.7-0+deb10u1         libpq5=11.7-0+deb10u1         libssl-dev=1.1.1d-0+deb10u3         libtiff5-dev=4.1.0+git191117-2~deb10u1         libxml2-dev=2.9.4+dfsg1-7+b3         libxml2=2.9.4+dfsg1-7+b3         libxslt1-dev=1.1.32-2.2~deb10u1         libxslt1.1=1.1.32-2.2~deb10u1         libzmq3-dev=4.3.1-4+deb10u1         libzmq5=4.3.1-4+deb10u1         luarocks=2.4.2+dfsg-1         nginx=1.14.2-2+deb10u1         pandoc=2.2.1-3+b2         pkg-config=0.29-6         python-dev=2.7.16-1         python3-dev=3.7.3-1         python3-distutils=3.7.3-1         python3-minimal=3.7.3-1         zlib1g-dev=1:1.2.11.dfsg-1         && luarocks install lua-resty-http 0.15-0         && curl -sL https://deb.nodesource.com/setup_12.x | bash -         && apt-get install -y --no-install-recommends         nodejs=12.17.0-1nodesource1         && curl https://bootstrap.pypa.io/get-pip.py | python3         && update-alternatives         --install /usr/bin/python python /usr/bin/python3 10         && pip3 install --no-cache-dir numpy==1.18.1     && pip3 install --no-cache-dir -r /opt/requirements.txt         && jupyter labextension install         @jupyter-widgets/jupyterlab-manager@2.0.0 --no-build     && jupyter labextension install @bokeh/jupyter_bokeh --no-build     && jupyter labextension install @jupyterlab/github --no-build     && jupyter serverextension enable jupyterlab_sql --py --sys-prefix     && jupyter lab build         && apt-get purge -y --auto-remove         build-essential         dirmngr         gpg         gpg-agent         libffi-dev         libfreetype6-dev         libjpeg62-turbo-dev         libmariadb-dev         libpng-dev         libpq-dev         libssl-dev         libtiff5-dev         libxml2-dev         libxslt1-dev         libzmq3-dev         pkg-config         python-dev         python3-dev         zlib1g-dev         && find /usr/local/lib/python3.7/ -type d -name tests -depth -exec rm -rf {} \;     && find /usr/local/lib/python3.7/ -type d -name test -depth -exec rm -rf {} \;     && find /usr/local/lib/python3.7/ -name __pycache__ -depth -exec rm -rf {} \;     && find /usr/local/lib/python3.7/ -name "*.pyc" -depth -exec rm -f {} \;         && npm cache clean --force         && rm -fr         /tmp/*         /root/{.cache,.config,.gnupg,.local,.log,.npm}         /usr/local/share/.cache         /var/{cache,log}/*         /var/lib/apt/lists/*' returned a non-zero code: 100
```